### PR TITLE
Alias for Phactory::define()

### DIFF
--- a/lib/Phactory.php
+++ b/lib/Phactory.php
@@ -65,6 +65,16 @@ class Phactory {
     }
 
     /*
+     * Alias for self::define()
+     *
+     * @param string $blueprint_name singular name of the table in the database
+     * @param array $defaults key => value pairs of column => value, or a phactory_blueprint
+     * @param array $associations array of phactory_associations
+     */
+    public static function defineBlueprint($blueprint_name, $defaults, $associations = array()) {
+        self::define($blueprint_name, $defaults, $associations = array());
+    }
+    /*
      * Instantiate a row in the specified table, optionally
      * overriding some or all of the default values.
      * The row is saved to the database, and returned


### PR DESCRIPTION
Hi Chris,

I have a bit of annoyance when using Phactory in Eclipse and a few other IDE's. The Phactory::define() method doesn't validate since Eclipse thinks that we are trying to call php's native define().

I am going to submit a pull request/patch that aliases the Phactory::define() method defineBlueprint().  In my honest opinion define() was not the best naming choice in your otherwise awesome component.
