### PR TITLE
Fix for strict standards warning when calling Phactory::get

### DIFF
--- a/lib/Phactory.php
+++ b/lib/Phactory.php
@@ -142,8 +142,10 @@ class Phactory {
      * @param array $byColumn
      * @return object Phactory_Row
      */
-    public static function get($table_name, $byColumns) {		
-        return array_shift(self::getAll($table_name, $byColumns));
+    public static function get($table_name, $byColumns) {
+        $allRows = self::getAll($table_name, $byColumns);
+        
+        return array_shift($allRows);
     }
 
     public static function getAll($table_name, $byColumns) {


### PR DESCRIPTION
First of all, thanks for the great work so far on Phactory!  I just recently started using it on a project and have found it to be very simple yet power enough to do everything that I need to do.

I was getting a strict standards warning when using Phactory::get ("Only variables should be passed by reference") and discovered that it was coming from the call to array_shift in Phactory::get.  Instead, I just used an intermediate variable to hold the result to be passed to array_shift.

http://stackoverflow.com/questions/2354609/strict-standards-only-variables-should-be-passed-by-reference
