### PR TITLE
Rowfill

### DIFF
--- a/lib/Phactory/Row.php
+++ b/lib/Phactory/Row.php
@@ -84,4 +84,14 @@ class Phactory_Row {
     public function __set($key, $value) {
         $this->_storage[$key] = $value;
     }
+
+    public function fill() {
+        $columns = $this->_table->getColumns();
+        foreach ($columns as $column) {
+            if ( ! isset($this->_storage[$column]) ) {
+               $this->_storage[$column] = null;
+            }
+        }
+        return $this;
+    }
 }

--- a/tests/phactory/Phactory/Phactory_RowTest.php
+++ b/tests/phactory/Phactory/Phactory_RowTest.php
@@ -60,7 +60,6 @@ class Phactory_RowTest extends PHPUnit_Framework_TestCase
         $data = array('name' => 'testname');
         $row = new Phactory_Row('user', $data);
         $arr = $row->toArray();
-
         $this->assertEquals($data, $arr);
 
         //changing the returned array shouldn't change the row
@@ -75,6 +74,20 @@ class Phactory_RowTest extends PHPUnit_Framework_TestCase
         $user = Phactory::create('user');
 
         $this->assertEquals($data, $user->toArray());
+    }
+
+    public function testFill()
+    {
+        $data = array('id' => 1);
+        $row = new Phactory_Row('user', $data);
+        $arr = $row->toArray();
+        
+        $this->assertEquals($data, $arr);
+
+        $data['name'] = null;
+        $arr = $row->fill()->toArray();
+
+        $this->assertEquals($data, $arr);
     }
 
 }


### PR DESCRIPTION
When creating rows with Phactory, omitted optional columns are filled with null in the database. This is convenient because I don't have to provide every column in my definition of of a table (which is subject to change unexpectedly/often). However, when I create objects from Phactory Rows, I often want them to mirror what is in the database - not what is in the internal storage of a Phactory Row (which doesn't account for those null columns).

To get arround this I am doing:
$user = Phactory::create('user');
$user = Phactory::get('user', array('id' => $user->getId());
$user_object = new User($user->toArray());

This will allow us to instead use:
$user = Phactory::create('user');
$user_object = new User($user->fill()->toArray());
