### PR TITLE
Ability to set a mongo record value to something other than a string

### DIFF
--- a/lib/Phactory/Mongo/Blueprint.php
+++ b/lib/Phactory/Mongo/Blueprint.php
@@ -8,7 +8,7 @@ class Blueprint {
     protected $_sequence;
 
     public function __construct($name, $defaults, $associations = array(), Phactory $phactory) {
-        $this->_collection = new Collection($name, true, $phactory); 
+        $this->_collection = new Collection($name, true, $phactory);
         $this->_defaults = $defaults;
         $this->_sequence = new Sequence();
 
@@ -102,7 +102,7 @@ class Blueprint {
     protected function _evalSequence(&$data) {
         $n = $this->_sequence->next();
         foreach($data as &$value) {
-            if(false !== strpos($value, '$')) {
+            if(is_string($value) && false !== strpos($value, '$')) {
                 $value = eval('return "'. stripslashes($value) . '";');
             }
         }

--- a/lib/Phactory/Mongo/Blueprint.php
+++ b/lib/Phactory/Mongo/Blueprint.php
@@ -101,10 +101,10 @@ class Blueprint {
 
     protected function _evalSequence(&$data) {
         $n = $this->_sequence->next();
-        foreach($data as &$value) {
+        array_walk_recursive($data,function(&$value) use ($n) {
             if(is_string($value) && false !== strpos($value, '$')) {
                 $value = eval('return "'. stripslashes($value) . '";');
             }
-        }
+        });
     }
 }

--- a/tests/Phactory/Mongo/PhactoryTest.php
+++ b/tests/Phactory/Mongo/PhactoryTest.php
@@ -131,11 +131,13 @@ class PhactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testDefineAndCreateWithSequence()
     {
-        $this->phactory->define('user', array('name' => 'user\$n'));
+        $tags = array('foo$n','bar$n');
+        $this->phactory->define('user', array('name' => 'user\$n', 'tags' => $tags));
 
         for($i = 0; $i < 5; $i++) {
             $user = $this->phactory->create('user');
             $this->assertEquals("user$i", $user['name']);
+            $this->assertEquals(array("foo$i","bar$i"),$user['tags']);
         }
     }
 

--- a/tests/Phactory/Mongo/PhactoryTest.php
+++ b/tests/Phactory/Mongo/PhactoryTest.php
@@ -65,18 +65,21 @@ class PhactoryTest extends \PHPUnit_Framework_TestCase
     public function testCreate()
     {
         $name = 'testuser';
+        $tags = array('one','two','three');
 
         // define and create user in db
-        $this->phactory->define('user', array('name' => $name));
+        $this->phactory->define('user', array('name' => $name, 'tags' => $tags));
         $user = $this->phactory->create('user');
 
         // test returned array
         $this->assertInternalType('array', $user);
         $this->assertEquals($user['name'], $name);
+        $this->assertEquals($user['tags'], $tags);
 
         // retrieve and test expected document from database
         $db_user = $this->db->users->findOne();
         $this->assertEquals($name, $db_user['name']);
+        $this->assertEquals($tags, $db_user['tags']);
     }
 
     public function testCreateWithOverrides()
@@ -88,7 +91,7 @@ class PhactoryTest extends \PHPUnit_Framework_TestCase
         $this->phactory->define('user', array('name' => $name));
         $user = $this->phactory->create('user', array('name' => $override_name));
 
-        // test returned array 
+        // test returned array
         $this->assertInternalType('array', $user);
         $this->assertEquals($user['name'], $override_name);
 
@@ -105,7 +108,7 @@ class PhactoryTest extends \PHPUnit_Framework_TestCase
                          array('name' => 'testuser'),
                          array('role' => $this->phactory->embedsOne('role')));
 
-        $role = $this->phactory->build('role'); 
+        $role = $this->phactory->build('role');
         $user = $this->phactory->createWithAssociations('user', array('role' => $role));
 
         $this->assertEquals($role['name'], $user['role']['name']);
@@ -145,7 +148,7 @@ class PhactoryTest extends \PHPUnit_Framework_TestCase
         $user = $this->phactory->create('user');
 
         // get() expected row from database
-        $db_user = $this->phactory->get('user', array('name' => $name)); 
+        $db_user = $this->phactory->get('user', array('name' => $name));
 
         // test retrieved db row
         $this->assertInternalType('array', $db_user);


### PR DESCRIPTION
The _evalSequence function of the Blueprint class forces all values of documents to be a string.  This pull request adds a check to that so that if a value is not a string it won't be eval'd.

This is needed because as Phactory stands now, there is no way to create a document with a value being an array of scalars such as

```
$phactory->define('user',array('tags'=>array('one','two','three')));
```

In the above case an embedded document does not work as you end up with an array of nested arrays otherwise.
