### PR TITLE
Add ability to register a primary key. Pair with @LiGang9090.

### DIFF
--- a/lib/Phactory/Sql/Blueprint.php
+++ b/lib/Phactory/Sql/Blueprint.php
@@ -29,6 +29,10 @@ class Blueprint {
         }
     }
 
+    public function setTablePrimaryKey($primary_key) {
+        $this->_table->setPrimaryKey($primary_key);
+    }    
+
     public function setDefaults($defaults) {
         $this->_defaults = $defaults;
     }

--- a/lib/Phactory/Sql/Phactory.php
+++ b/lib/Phactory/Sql/Phactory.php
@@ -48,12 +48,13 @@ class Phactory {
      * @param array $defaults key => value pairs of column => value, or a phactory_blueprint
      * @param array $associations array of phactory_associations
      */
-    public function define($blueprint_name, $defaults = array(), $associations = array()) {
+    public function define($blueprint_name, $defaults = array(), $associations = array(), $primary_key = null) {
         if($defaults instanceof Blueprint) {
             $blueprint = $defaults;
         } else {
             $blueprint = new Blueprint($blueprint_name, $defaults, $associations, $this);
         }
+        $blueprint->setTablePrimaryKey($primary_key);
         $this->_blueprints[$blueprint_name] = $blueprint;
     }
 

--- a/lib/Phactory/Sql/Table.php
+++ b/lib/Phactory/Sql/Table.php
@@ -6,6 +6,7 @@ class Table {
     protected $_singular;
     protected $_name;
     protected $_db_util;
+    protected $_primary_key;
     protected $_phactory;
 
     public function __construct($singular_name, $pluralize = true, Phactory $phactory) {
@@ -19,6 +20,10 @@ class Table {
         }
     }
 
+    public function setPrimaryKey($primary_key){
+        return $this->_primary_key = $primary_key;
+    }
+
     public function getName() {
         return $this->_name;
     }
@@ -28,6 +33,9 @@ class Table {
     }
 
     public function getPrimaryKey() {
+        if($this->_primary_key){
+            return $this->_primary_key;
+        }
         return $this->_db_util->getPrimaryKey($this->_name);
     }
 

--- a/tests/Phactory/Sql/TableTest.php
+++ b/tests/Phactory/Sql/TableTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Phactory\Sql;
+
+class TableTest extends \PHPUnit_Framework_TestCase
+{
+	protected $pdo;
+    protected $phactory;
+
+    protected function setUp()
+    {
+		$this->pdo = new \PDO("sqlite:test.db");
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $this->pdo->exec("CREATE TABLE `users` ( id INTEGER PRIMARY KEY, name TEXT )");
+        $this->pdo->exec("CREATE TABLE `settings` ( id INTEGER, name TEXT )");
+
+        $this->phactory = new Phactory($this->pdo);
+    }
+
+    protected function tearDown()
+    {        
+        $this->pdo->exec("DROP TABLE `settings`");
+        $this->pdo->exec("DROP TABLE `users`");
+		$this->phactory->reset();
+    }
+
+    public function testGetPrimaryKeyWhenPrimaryKeyExists()
+    {
+        $table = new Table('user', true, $this->phactory);
+        $this->assertEquals('id', $table->getPrimaryKey());
+    }
+    
+    public function testGetPrimaryKeyWhenPrimaryKeyRegistered()
+    {
+        $table = new Table('setting', true, $this->phactory);
+        $table->setPrimaryKey('id');
+        $this->assertEquals('id', $table->getPrimaryKey());
+    }
+
+
+}
+?>


### PR DESCRIPTION
We are working on a legacy project. Some of our database doesn't have a primary key. 

Instead, they have unique key with auto increment.

We think it would be helpful if this package can support register a key as primary key for MySQL.
