### PR TITLE
Stop using deprecated parameter

### DIFF
--- a/lib/Phactory/Mongo/Blueprint.php
+++ b/lib/Phactory/Mongo/Blueprint.php
@@ -88,7 +88,7 @@ class Blueprint {
      */
     public function create($overrides = array(), $associated = array()) {
         $data = $this->build($overrides, $associated);
-        $this->_collection->insert($data,array("safe"=>true));
+        $this->_collection->insert($data,array("w"=>1));
         return $data;
     }
 


### PR DESCRIPTION
With recent versions of the PHP MongoDB driver, the safe option is deprecated and the following error is thrown:

```
MongoCollection::insert(): The 'safe' option is deprecated, please use 'w' instead
```

This pull request should fix issue #38.
