### PR TITLE
Fix MongoDB Collection.insert() error

### DIFF
--- a/lib/Phactory/Mongo/Collection.php
+++ b/lib/Phactory/Mongo/Collection.php
@@ -30,6 +30,11 @@ class Collection {
         return $this->_name;
     }
 
+    public function insert($data, $options) {
+        $coll = $this->_collection;
+        return $coll->insert($data,$options);
+    }
+
     public function __call($func, $args) {
         return call_user_func_array(array($this->_collection, $func), $args);
     }


### PR DESCRIPTION
Collection insert() parameters are expected to be passed by reference. PHP 7.4 seems to enforce that pretty rigidly, triggering an error when the method is called. The call_user_func_array() approach to proxying collection methods seemed to force parameters into a pass-by-value state. This pull request makes the insert() method work again.